### PR TITLE
Editing GitHub Address

### DIFF
--- a/src/data/verifiers-registry.json
+++ b/src/data/verifiers-registry.json
@@ -372,7 +372,7 @@
       "email": "1286679231@qq.com, 297511521@qq.com",
       "fil_slack_id": "chuangshiIPFS, U015T4BULA2",
       "github_user": [
-        "Genesis/1ane-1",
+        "1ane-1",
         "KIMQI001"
       ],
       "ldn_config": {


### PR DESCRIPTION
Changed the GitHub name for one notary, Genesis. Clearing an error, while adding these GitHub handle accounts as users in the client onboarding repo.